### PR TITLE
Add config-support for retention policies other than "autogen"

### DIFF
--- a/ElOverBlik-helper/App/Einfluxer.py
+++ b/ElOverBlik-helper/App/Einfluxer.py
@@ -2,9 +2,10 @@ from logging import warning, info
 
 class Einfluxer:
 
-    def __init__(self, client, database):
+    def __init__(self, client, database, retentionPolicy):
         self.Client = client
         self.Database = database
+        self.retentionPolicy = retentionPolicy
 
         if not self.DbExsist(self.Database):
             self.CreateDb()
@@ -22,6 +23,6 @@ class Einfluxer:
         self.Client.create_database(self.Database)
     
     def GotValuesForDate(self, data, measurementName, name):
-        query = 'SELECT last("value") FROM "' + self.Database + '"."autogen"."'+ measurementName +'" WHERE ("metering_date" = \'' + data["tags"]["metering_date"] + '\' AND ("Name" = \'' + name + '\' OR "Name" = \'\')) GROUP BY "Name"'
+        query = 'SELECT last("value") FROM "' + self.Database + '"."' + self.retentionPolicy + '"."'+ measurementName +'" WHERE ("metering_date" = \'' + data["tags"]["metering_date"] + '\' AND ("Name" = \'' + name + '\' OR "Name" = \'\')) GROUP BY "Name"'
         result = self.Client.query(query)
         return len(result.raw['series']) > 0

--- a/ElOverBlik-helper/App/main.py
+++ b/ElOverBlik-helper/App/main.py
@@ -51,7 +51,7 @@ for extractor in extractors:
         if not Einf.GotValuesForDate(data[0],extractor.measurementName,extractor.name):
             message = "Inserted data for: {}".format(data[0]['tags']['Metering date'])
             try:
-                Einf.Client.write_points(data)
+                Einf.Client.write_points(data, retention_policy=options['db_retention_policy'])
             except:
                 e = exc_info()[0]
                 message = "Inserted data for: {}".format(data[0]['tags']['Metering date'])

--- a/ElOverBlik-helper/App/main.py
+++ b/ElOverBlik-helper/App/main.py
@@ -33,7 +33,7 @@ logging.info("Got {} for database".format(options['db_name']))
 
 client = InfluxDBClient(host=options['db_ip'], port=options['db_port'], username=options['db_user'], password=options['db_pass'])
 extractors = ExtractorBuilder(options).build()
-Einf = Einfluxer(client, options['db_name'])
+Einf = Einfluxer(client, options['db_name'], options['db_retention_policy'])
 
 cumulativeMessage = ""
 

--- a/ElOverBlik-helper/config.json
+++ b/ElOverBlik-helper/config.json
@@ -1,6 +1,6 @@
 {
   "name": "ElOverBlik-Helper",
-  "version": "0.14.1",
+  "version": "0.15",
   "slug": "eloverblik_helper",
   "hassio_api": false,
   "homeassistant_api": true,

--- a/ElOverBlik-helper/config.json
+++ b/ElOverBlik-helper/config.json
@@ -12,6 +12,7 @@
   "options": {
     "db_ip": "192.168.1.10",
     "db_name": "eloversigt",
+    "db_retention_policy": "autogen",
     "db_measurement_name": "Energy",
     "db_port": 8086,
     "db_user": "",
@@ -28,6 +29,7 @@
   "schema": {
     "db_ip": "str",
     "db_name": "str",
+    "db_retention_policy": "str",
     "db_measurement_name": "str",
     "db_port": "int",
     "db_user": "str",

--- a/ElOverBlik-helper/config.json
+++ b/ElOverBlik-helper/config.json
@@ -1,6 +1,6 @@
 {
   "name": "ElOverBlik-Helper",
-  "version": "0.14",
+  "version": "0.14.1",
   "slug": "eloverblik_helper",
   "hassio_api": false,
   "homeassistant_api": true,


### PR DESCRIPTION
My InfluxDb does not have an "autogen" RP anymore, so in order to use the (otherwise great) add-on, I need a config-option for speifying the RT name (it defaults to "autogen" ofc)